### PR TITLE
drivers/misc: fingerprint/goodix: Stop reporting GF_KEY_HOME to userspace

### DIFF
--- a/drivers/misc/goodix/gf_spi.c
+++ b/drivers/misc/goodix/gf_spi.c
@@ -363,9 +363,7 @@ static void gf_kernel_key_input(struct gf_dev *gf_dev, struct gf_key *gf_key)
 {
 	uint32_t key_input = 0;
 
-	if (gf_key->key == GF_KEY_HOME) {
-		key_input = GF_KEY_INPUT_HOME;
-	} else if (gf_key->key == GF_KEY_POWER) {
+	if (gf_key->key == GF_KEY_POWER) {
 		key_input = GF_KEY_INPUT_POWER;
 	} else if (gf_key->key == GF_KEY_CAMERA) {
 		key_input = GF_KEY_INPUT_CAMERA;
@@ -384,10 +382,6 @@ static void gf_kernel_key_input(struct gf_dev *gf_dev, struct gf_key *gf_key)
 		input_sync(gf_dev->input);
 	}
 
-	if (gf_key->key == GF_KEY_HOME) {
-		input_report_key(gf_dev->input, key_input, gf_key->value);
-		input_sync(gf_dev->input);
-	}
 }
 
 static long gf_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)

--- a/drivers/misc/goodix/gf_spi.h
+++ b/drivers/misc/goodix/gf_spi.h
@@ -54,7 +54,6 @@ typedef enum gf_nav_event {
 
 typedef enum gf_key_event {
 	GF_KEY_NONE = 0,
-	GF_KEY_HOME,
 	GF_KEY_POWER,
 	GF_KEY_MENU,
 	GF_KEY_BACK,


### PR DESCRIPTION
* Nuke Useless Non-Working Feature Conflict With Screenshot Event Exposed On Android 12